### PR TITLE
Adding button and axes identifiers for different controllers.

### DIFF
--- a/static/soccer/soccer.js
+++ b/static/soccer/soccer.js
@@ -340,7 +340,7 @@ var SoccerGame = function(canvas) {
   this.rightTeam = new Team('#8080FF', this);
 
   this.gameControls = new GameControls({
-    // 'debug': true,
+    'debug': true,
     'controller': {
       'directions': 'stick'
     },


### PR DESCRIPTION
There is a standard controller definition at https://w3c.github.io/gamepad/#remapping however not all controllers use it.
These changes at least document what buttons/axes are which for the 2 controllers I have (1 standard, 1 non standard)